### PR TITLE
GHO-214: add the Article Card lists

### DIFF
--- a/config/core.entity_form_display.paragraph.article_card_list.default.yml
+++ b/config/core.entity_form_display.paragraph.article_card_list.default.yml
@@ -1,0 +1,25 @@
+uuid: 1a51f9e7-d1c1-45b9-8fef-2eb263260137
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.article_card_list.field_articles
+    - paragraphs.paragraphs_type.article_card_list
+id: paragraph.article_card_list.default
+targetEntityType: paragraph
+bundle: article_card_list
+mode: default
+content:
+  field_articles:
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_form_display.paragraph.article_card_list.default.yml
+++ b/config/core.entity_form_display.paragraph.article_card_list.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.article_card_list.field_articles
+    - field.field.paragraph.article_card_list.field_emphasize_first_row
     - paragraphs.paragraphs_type.article_card_list
 id: paragraph.article_card_list.default
 targetEntityType: paragraph
@@ -11,7 +12,7 @@ bundle: article_card_list
 mode: default
 content:
   field_articles:
-    weight: 0
+    weight: 1
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -19,6 +20,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_emphasize_first_row:
+    weight: 0
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
 hidden:
   created: true

--- a/config/core.entity_form_display.paragraph.heading.default.yml
+++ b/config/core.entity_form_display.paragraph.heading.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.heading.field_pre_title
     - field.field.paragraph.heading.field_title
     - paragraphs.paragraphs_type.heading
 id: paragraph.heading.default
@@ -10,8 +11,16 @@ targetEntityType: paragraph
 bundle: heading
 mode: default
 content:
-  field_title:
+  field_pre_title:
     weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_title:
+    weight: 1
     settings:
       size: 60
       placeholder: ''

--- a/config/core.entity_form_display.paragraph.heading.default.yml
+++ b/config/core.entity_form_display.paragraph.heading.default.yml
@@ -1,0 +1,23 @@
+uuid: 401ef48b-db11-4354-81c3-f73411f5b574
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.heading.field_title
+    - paragraphs.paragraphs_type.heading
+id: paragraph.heading.default
+targetEntityType: paragraph
+bundle: heading
+mode: default
+content:
+  field_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.node.article.teaser_card.yml
+++ b/config/core.entity_view_display.node.article.teaser_card.yml
@@ -1,0 +1,67 @@
+uuid: e3543f02-227e-4016-97d6-2e138c07ed5a
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser_card
+    - field.field.node.article.field_appeals
+    - field.field.node.article.field_author
+    - field.field.node.article.field_caption
+    - field.field.node.article.field_hero_image
+    - field.field.node.article.field_paragraphs
+    - field.field.node.article.field_pdf
+    - field.field.node.article.field_report_link
+    - field.field.node.article.field_section
+    - field.field.node.article.field_summary
+    - field.field.node.article.field_thumbnail_image
+    - image.style.652_x_489
+    - node.type.article
+  module:
+    - layout_builder
+    - media
+    - text
+    - user
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: false
+id: node.article.teaser_card
+targetEntityType: node
+bundle: article
+mode: teaser_card
+content:
+  field_hero_image:
+    type: media_thumbnail
+    weight: 0
+    label: hidden
+    settings:
+      image_style: 652_x_489
+      image_link: ''
+    third_party_settings: {  }
+    region: content
+  field_section:
+    weight: 1
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_summary:
+    type: text_trimmed
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      trim_length: 220
+    third_party_settings: {  }
+hidden:
+  field_appeals: true
+  field_author: true
+  field_caption: true
+  field_paragraphs: true
+  field_pdf: true
+  field_report_link: true
+  field_thumbnail_image: true
+  langcode: true
+  links: true

--- a/config/core.entity_view_display.paragraph.article_card_list.default.yml
+++ b/config/core.entity_view_display.paragraph.article_card_list.default.yml
@@ -1,0 +1,22 @@
+uuid: dbc6fc94-5493-4b49-b2ae-5a29f26b5edd
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.article_card_list.field_articles
+    - paragraphs.paragraphs_type.article_card_list
+id: paragraph.article_card_list.default
+targetEntityType: paragraph
+bundle: article_card_list
+mode: default
+content:
+  field_articles:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: teaser_card
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden: {  }

--- a/config/core.entity_view_display.paragraph.article_card_list.default.yml
+++ b/config/core.entity_view_display.paragraph.article_card_list.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.article_card_list.field_articles
+    - field.field.paragraph.article_card_list.field_emphasize_first_row
     - paragraphs.paragraphs_type.article_card_list
 id: paragraph.article_card_list.default
 targetEntityType: paragraph
@@ -18,5 +19,15 @@ content:
       link: false
     third_party_settings: {  }
     type: entity_reference_entity_view
+    region: content
+  field_emphasize_first_row:
+    weight: 1
+    label: hidden
+    settings:
+      format: custom
+      format_custom_true: show-2col
+      format_custom_false: default
+    third_party_settings: {  }
+    type: boolean
     region: content
 hidden: {  }

--- a/config/core.entity_view_display.paragraph.heading.default.yml
+++ b/config/core.entity_view_display.paragraph.heading.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.heading.field_pre_title
     - field.field.paragraph.heading.field_title
     - paragraphs.paragraphs_type.heading
 id: paragraph.heading.default
@@ -10,8 +11,16 @@ targetEntityType: paragraph
 bundle: heading
 mode: default
 content:
-  field_title:
+  field_pre_title:
     weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_title:
+    weight: 1
     label: hidden
     settings:
       link_to_entity: false

--- a/config/core.entity_view_display.paragraph.heading.default.yml
+++ b/config/core.entity_view_display.paragraph.heading.default.yml
@@ -1,0 +1,21 @@
+uuid: 9d7b8b3c-ddc5-4b43-b6e0-9d6732bae6a4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.heading.field_title
+    - paragraphs.paragraphs_type.heading
+id: paragraph.heading.default
+targetEntityType: paragraph
+bundle: heading
+mode: default
+content:
+  field_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/config/core.entity_view_mode.node.teaser_card.yml
+++ b/config/core.entity_view_mode.node.teaser_card.yml
@@ -1,0 +1,10 @@
+uuid: a6d67d56-6625-482e-9b8e-de32fe336257
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.teaser_card
+label: 'Teaser (Card)'
+targetEntityType: node
+cache: true

--- a/config/field.field.paragraph.article_card_list.field_articles.yml
+++ b/config/field.field.paragraph.article_card_list.field_articles.yml
@@ -1,0 +1,29 @@
+uuid: 6f129d5c-cb29-4277-85f5-9cf067003018
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_articles
+    - node.type.article
+    - paragraphs.paragraphs_type.article_card_list
+id: paragraph.article_card_list.field_articles
+field_name: field_articles
+entity_type: paragraph
+bundle: article_card_list
+label: Articles
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      article: article
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/field.field.paragraph.article_card_list.field_emphasize_first_row.yml
+++ b/config/field.field.paragraph.article_card_list.field_emphasize_first_row.yml
@@ -1,0 +1,23 @@
+uuid: 384308e1-5674-41a7-9eab-db54ac0a4638
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_emphasize_first_row
+    - paragraphs.paragraphs_type.article_card_list
+id: paragraph.article_card_list.field_emphasize_first_row
+field_name: field_emphasize_first_row
+entity_type: paragraph
+bundle: article_card_list
+label: 'Show first two items in 2-column layout?'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/config/field.field.paragraph.heading.field_pre_title.yml
+++ b/config/field.field.paragraph.heading.field_pre_title.yml
@@ -1,0 +1,19 @@
+uuid: 5482fab5-b435-4bd0-a135-a0ec68590cb7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_pre_title
+    - paragraphs.paragraphs_type.heading
+id: paragraph.heading.field_pre_title
+field_name: field_pre_title
+entity_type: paragraph
+bundle: heading
+label: Pre-title
+description: 'Adds a small line of text above the heading. e.g. "Chapter One"'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.field.paragraph.heading.field_title.yml
+++ b/config/field.field.paragraph.heading.field_title.yml
@@ -1,0 +1,19 @@
+uuid: bda4508a-a2f4-4b4c-b203-4eccb13f5ce7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_title
+    - paragraphs.paragraphs_type.heading
+id: paragraph.heading.field_title
+field_name: field_title
+entity_type: paragraph
+bundle: heading
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.storage.paragraph.field_articles.yml
+++ b/config/field.storage.paragraph.field_articles.yml
@@ -1,0 +1,20 @@
+uuid: a6dad788-9e3a-4d6d-86e0-e40eb235ef1f
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_articles
+field_name: field_articles
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_emphasize_first_row.yml
+++ b/config/field.storage.paragraph.field_emphasize_first_row.yml
@@ -1,0 +1,18 @@
+uuid: 0ffccf6e-0fd6-4407-8aa9-af60f361128d
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_emphasize_first_row
+field_name: field_emphasize_first_row
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.paragraph.field_pre_title.yml
+++ b/config/field.storage.paragraph.field_pre_title.yml
@@ -1,0 +1,21 @@
+uuid: 4dc1ae05-70b7-403d-805b-4c5e7bb7c3fe
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_pre_title
+field_name: field_pre_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/paragraphs.paragraphs_type.article_card_list.yml
+++ b/config/paragraphs.paragraphs_type.article_card_list.yml
@@ -1,0 +1,10 @@
+uuid: 80df4b5e-4706-40a8-8fc0-6493bb227cc9
+langcode: en
+status: true
+dependencies: {  }
+id: article_card_list
+label: 'Article Card List'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/config/paragraphs.paragraphs_type.heading.yml
+++ b/config/paragraphs.paragraphs_type.heading.yml
@@ -1,0 +1,10 @@
+uuid: e52f38df-8180-4eb6-b4cf-a74e1b68eaed
+langcode: en
+status: true
+dependencies: {  }
+id: heading
+label: Heading
+icon_uuid: null
+icon_default: null
+description: 'A generic heading.'
+behavior_plugins: {  }

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -148,3 +148,13 @@ gho-article-list:
   css:
     theme:
       components/gho-article-list/gho-article-list.css: {}
+
+gho-article-card-list:
+  css:
+    theme:
+      components/gho-article-card-list/gho-article-card-list.css: {}
+
+gho-article-card:
+  css:
+    theme:
+      components/gho-article-card/gho-article-card.css: {}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -56,6 +56,11 @@ gho-social-links:
   js:
     components/gho-social-links/gho-social-links.js: {}
 
+gho-heading:
+  css:
+    theme:
+      components/gho-heading/gho-heading.css: {}
+
 gho-footnotes:
   js:
     components/gho-footnotes/gho-footnotes.js: {}

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -81,6 +81,18 @@ function common_design_subtheme_preprocess_field(&$variables) {
 }
 
 /**
+ * Implements hook_theme_suggestions_HOOK().
+ */
+function common_design_subtheme_theme_suggestions_field(array $variables) {
+  $suggestions = [];
+  $element = $variables['element'];
+
+  $suggestions[] = 'field__' . $element['#entity_type'] . '__' . $element['#field_name'] . '__' . $element['#bundle']  . '__' . $element['#view_mode'];
+
+  return $suggestions;
+}
+
+/**
  * Implements hook_preprocess_node().
  *
  * Use the page title block for the title and display the local tasks below it.

--- a/html/themes/custom/common_design_subtheme/components/gho-article-card-list/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card-list/README.md
@@ -1,0 +1,5 @@
+Global Humanitarian Overview - Article card list Component
+==========================================================
+
+List of article cards for the secion index paragraphs on the homepage with
+an optional title.

--- a/html/themes/custom/common_design_subtheme/components/gho-article-card-list/gho-article-card-list.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card-list/gho-article-card-list.css
@@ -18,9 +18,21 @@
   gap: 1rem;
 }
 
-/* Default:  a basic 3-column layout */
 @media screen and (min-width: 606px) {
+  /**
+   * Default: a basic 3-column layout
+   */
   .gho-article-card-list__list .field__items > .field__item {
-    flex: 1 0 30%;
+    flex-grow: 0;
+    flex-shrink: 0;
+    flex-basis: calc((100% - 2rem) / 3);
+  }
+
+  /**
+   * When the "Show first row as 2-column" checkbox is enabled, we make the
+   * first row 2-col, then the rest are still 3-col.
+   */
+  .gho-article-card-list--show-2col .field__items > .field__item:nth-child(-n + 2) {
+    flex-basis: calc((100% - 1rem) / 2);
   }
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-article-card-list/gho-article-card-list.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card-list/gho-article-card-list.css
@@ -1,0 +1,26 @@
+.gho-article-card-list {
+  margin-top: 4.5rem;
+}
+
+.gho-article-card-list__title {
+  margin: 0 0 1.5rem 0;
+  color: #1f1f1f;
+  font-size: 1.3125rem;
+  font-weight: 700;
+  line-height: 1.5rem;
+}
+
+.gho-article-card-list__list .field__items {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-flow: row wrap;
+  gap: 1rem;
+}
+
+/* Default:  a basic 3-column layout */
+@media screen and (min-width: 606px) {
+  .gho-article-card-list__list .field__items > .field__item {
+    flex: 1 0 30%;
+  }
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-article-card/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Article Card Component
+=====================================================
+
+Styling for the articles when viewed in "Teaser (Card)" mode. Meant to be displayed in series so that cards stack next to each other in a grid-like pattern.

--- a/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
@@ -1,0 +1,59 @@
+.gho-article-card {
+  height: 100%;
+  border: 1px solid var(--cd-grey--light);
+}
+
+/* Hide the "scroll down" SVG.
+ *
+ * Since Cards are used extensively on homepage, and our Hero Image template
+ * uses a conditional to show the SVG when `is_front` is true, we hide these
+ * SVGs with display:none in order to also hide them from the a11y tree.
+ *
+ * @see html/themes/custom/common_design_subtheme/templates/fields/field--node--field-hero-image--article.html.twig
+ */
+.gho-article-card .gho-hero-image__scrolldown {
+  display: none;
+}
+
+/* Image */
+.gho-article-card .gho-hero-image {
+  position: relative;
+  margin-bottom: 1rem;
+}
+.gho-article-card img::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left:  0;
+
+  border: 1px solid #ddd;
+  background: var(--cd-grey--light);
+}
+.gho-article-card img::after {
+  content: 'Broken image:  ' attr(alt);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  z-index: 10;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: #888;
+}
+
+/* Section name */
+.gho-article-card .gho-article__pre-title {
+  margin: 1rem 0;
+  padding: 0 1rem;
+  color: var(--cd-ocha-blue);
+  font-size: var(--cd-font-size--small);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+/* Text summary */
+.gho-article-card .field--name-field-summary {
+  margin: 1rem 0;
+  padding: 0 1rem;
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
@@ -1,6 +1,7 @@
 .gho-article-card {
+  --gho-article-card-border-color: #ddd;
   height: 100%;
-  border: 1px solid var(--cd-grey--light);
+  border: 1px solid var(--gho-article-card-border-color);
 }
 
 /* Hide the "scroll down" SVG.

--- a/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
@@ -52,6 +52,15 @@
   text-transform: uppercase;
 }
 
+/* Article title */
+.gho-article-card .gho-article-card__title {
+  margin: 1em 0;
+  padding: 0 1rem;
+  color: var(--cd-black);
+  font-size: 1em;
+  font-weight: 700;
+}
+
 /* Text summary */
 .gho-article-card .field--name-field-summary {
   margin: 1rem 0;

--- a/html/themes/custom/common_design_subtheme/components/gho-heading/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-heading/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Heading Paragraph
+================================================
+
+Basic heading paragraph. Many components include their own heading, but sometimes you just gotta add your own, you know?

--- a/html/themes/custom/common_design_subtheme/components/gho-heading/gho-heading.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-heading/gho-heading.css
@@ -1,0 +1,10 @@
+.gho-heading {
+  margin: 4.5rem 0 0 0;
+}
+
+.gho-heading .gho-heading__heading {
+  margin: 0;
+  font-size: var(--cd-font-size--2xlarge);
+  font-weight: 700;
+  color: var(--cd-black);
+}

--- a/html/themes/custom/common_design_subtheme/components/gho-heading/gho-heading.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-heading/gho-heading.css
@@ -1,8 +1,38 @@
 .gho-heading {
-  margin: 4.5rem 0 0 0;
+  --gho-heading-border-color: #ddd;
+  --gho-heading-margin-top: 9rem;
+  margin: var(--gho-heading-margin-top) 0 0 0;
 }
 
-.gho-heading .gho-heading__heading {
+.gho-heading::before {
+  content: '';
+  position: absolute;
+  width: 100vw;
+  max-width: 100%;
+  left: 50%;
+  margin: 0;
+  padding: 0;
+  transform: translateX(-50%) translateY(-4.5rem);
+  border-top: 1px solid var(--gho-heading-border-color);
+}
+
+@media screen and (min-width: 1400px) {
+  .gho-heading::before {
+    width: 99vw;
+    max-width: 100vw;
+  }
+}
+
+.gho-heading__pre-title {
+  display: block;
+  color: var(--cd-grey--mid);
+  font-size: var(--cd-font-size--small);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.gho-heading__title {
+  display: block;
   margin: 0;
   font-size: var(--cd-font-size--2xlarge);
   font-weight: 700;

--- a/html/themes/custom/common_design_subtheme/components/gho-home-page/gho-home-page.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-home-page/gho-home-page.css
@@ -189,13 +189,7 @@
 /**
  * Homepage intro text.
  */
-.gho-home-page__content > .gho-text {
-  /* GHO-148: Needs and Requirements now has a border-bottom so we're removing
-     the margin/border here */
-  margin-top: 0;
-  padding-top: 3.75rem;
-  text-align: center;
-}
+.gho-home-page__content > .gho-text {}
 .gho-home-page__content > .gho-text .gho-text__text {
   max-width: none;
 }
@@ -215,6 +209,13 @@
 }
 .gho-home-page__content > .gho-text .gho-text__text p {
   margin: 0;
+}
+
+/**
+ * Customize margins when Text appears directly after a Heading.
+ */
+.gho-home-page__content > .gho-heading + .gho-text {
+  margin-top: 1rem;
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/components/gho-home-page/gho-home-page.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-home-page/gho-home-page.css
@@ -189,7 +189,6 @@
 /**
  * Homepage intro text.
  */
-.gho-home-page__content > .gho-text {}
 .gho-home-page__content > .gho-text .gho-text__text {
   max-width: none;
 }

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-pre-title--heading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-pre-title--heading.html.twig
@@ -1,0 +1,5 @@
+{% for item in items %}
+  <span class="gho-heading__pre-title">
+    {{ item.content }}<span class="visually-hidden">:</span>
+  </span>
+{% endfor %}

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-title--heading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-title--heading.html.twig
@@ -1,0 +1,5 @@
+{% for item in items %}
+  <span class="gho-heading__title">
+    {{ item.content }}
+  </span>
+{% endfor %}

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
@@ -1,0 +1,96 @@
+{#
+/**
+ * @file
+ * Theme override to display an Article node in Teaser (Card) view mode.
+ *
+ * Overrides core/themes/classy/templates/content/node.html.twig.
+ *
+ * Note: the common_design_subtheme_preprocess_node() adds those variables:
+ * - title: node title
+ * - local_tasks: local tasks (edit etc.)
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: (optional) The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: (optional) Themed creation date field.
+ * - author_name: (optional) Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-article-card') }}
+{%
+  set classes = [
+    'node',
+    'node--type-' ~ node.bundle|clean_class,
+    node.isPromoted() ? 'node--promoted',
+    node.isSticky() ? 'node--sticky',
+    not node.isPublished() ? 'node--unpublished',
+    view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
+    'gho-article-card',
+    'clearfix',
+  ]
+%}
+<article{{ attributes.addClass(classes) }}>
+  <div{{ content_attributes.addClass('node__content').addClass('gho-article__content') }}>
+    {{ content }}
+  </div>
+</article>

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
@@ -91,6 +91,9 @@
 %}
 <article{{ attributes.addClass(classes) }}>
   <div{{ content_attributes.addClass('node__content').addClass('gho-article__content') }}>
-    {{ content }}
+    {{ content.field_hero_image }}
+    {{ content.field_section }}
+    <h3 class="gho-article-card__title">{{ node.getTitle }}</h3>
+    {{ content.field_summary }}
   </div>
 </article>

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--achievement.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--achievement.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-card-list.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-card-list.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-card-list.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-card-list.html.twig
@@ -48,11 +48,12 @@
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
     'gho-article-card-list',
+    'gho-article-card-list--' ~ content.field_emphasize_first_row|render|striptags|trim|clean_class,
     'content-width',
   ]
 %}
 {% set title = content.field_title|render %}
-{% set content = content|without('field_title')|render %}
+{% set content = content|without('field_title','field_emphasize_first_row')|render %}
 {% if content %}
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-card-list.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-card-list.html.twig
@@ -1,0 +1,69 @@
+{#
+/**
+ * @file
+ * Theme implementation for an Article Card List paragraph.
+ *
+ * Overrides paragraphs/templates/paragraph.html.twig.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.a
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-article-card-list') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-article-card-list',
+    'content-width',
+  ]
+%}
+{% set title = content.field_title|render %}
+{% set content = content|without('field_title')|render %}
+{% if content %}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {% if title %}
+        <h3 class="gho-article-card-list__title">{{ title }}</h3>
+      {% endif %}
+      <div class="gho-article-card-list__list">
+        {{ content }}
+      </div>
+    {% endblock %}
+  </div>
+{% endblock paragraph %}
+{% endif %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-list.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--article-list.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--bottom-figure-row--top-figures.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--bottom-figure-row--top-figures.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--bottom-figure-row.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--bottom-figure-row.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--facts-and-figures.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--facts-and-figures.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--further-reading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--further-reading.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--heading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--heading.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--heading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--heading.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Theme implementation for a Heading paragraph.
+ *
+ * Overrides paragraphs/templates/paragraph.html.twig.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.a
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-heading') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-heading',
+    'content-width',
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      <h2 class="gho-heading__heading">{{ content|render|striptags }}</h2>
+    {% endblock %}
+  </div>
+{% endblock paragraph %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--heading.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--heading.html.twig
@@ -54,7 +54,7 @@
 {% block paragraph %}
   <div{{ attributes.addClass(classes) }}>
     {% block content %}
-      <h2 class="gho-heading__heading">{{ content|render|striptags }}</h2>
+      <h2 class="gho-heading__heading">{{ content }}</h2>
     {% endblock %}
   </div>
 {% endblock paragraph %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--image--hero-image.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--image--hero-image.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--image-with-text--facts-and-figures.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--image-with-text--facts-and-figures.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--interactive-content.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--interactive-content.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--layout.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--layout.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--needs-and-requirements.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--needs-and-requirements.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--photo-gallery.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--photo-gallery.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--section-index.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--section-index.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--separator.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--separator.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--story.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--story.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--sub-article.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--sub-article.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--text.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--text.html.twig
@@ -33,7 +33,7 @@
  * - logged_in: Flag for authenticated user status. Will be true when the
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.a
+ *   is an administrator.
  *
  * @see template_preprocess_paragraph()
  *


### PR DESCRIPTION
# GHO-214

The homepage for this year has decided to adopt the "card list" style that GHI comps reliev heavily upon. This branch adds some Paragraph types, CD subtheme components, and removes a few Homepage customizations in order to tie it all together. Sample screenshot from Firefox below. It demonstrates the "show first row as 2-column" option in the Paragraph, and a second section without the 2-col treatment.

## Testing

1. It's easiest to grab a snapshot of the dev DB first. Doing so will give you a collection of fully-written articles to choose from for the actual setup.
2. Edit the Homepage and in the Paragraphs field add the following:
  - Heading paragraph
  - Text paragraph
  - Article Card List paragraph, and choose 5 nodes. Check the box to make the first row 2-col.
  - Heading paragraph, pre-title should be "Chapter One"
  - Text paragraph
  - Article Card List, and choose 6 nodes. Leave box unchecked.
3. Save node and view the page

![GHO-214-testing-result](https://user-images.githubusercontent.com/254753/140338829-adeb0bb3-2c58-4265-86a6-c13f6283a9bb.png)
