### PR TITLE
GHO-215: get Needs/Requirements import to work

### DIFF
--- a/html/modules/custom/gho_figures/src/Form/GhoFiguresImportNeedsAndRequirementsFiguresForm.php
+++ b/html/modules/custom/gho_figures/src/Form/GhoFiguresImportNeedsAndRequirementsFiguresForm.php
@@ -1175,7 +1175,7 @@ class GhoFiguresImportNeedsAndRequirementsFiguresForm extends FormBase {
   public static function call(array $arguments, &$data) {
     $callable = array_shift($arguments);
     $arguments[] = &$data;
-    return call_user_func_array($callable, $arguments);
+    return call_user_func_array($callable, array_values($arguments));
   }
 
   /**


### PR DESCRIPTION
# GHO-215

I couldn't import figures and the error ended up being related to PHP 8 named arguments. [I found a solution that core implemented](https://www.drupal.org/project/drupal/issues/3174022) and it unblocked our imports too.

## Testing

1. Log in as admin
2. Grab the CSV I uploaded to the ticket (figures are not for public consumption yet)
3. Go to http://gho-2022-site.docksal/admin/content/needs_and_requirements/import and upload the CSV
4. It should report 42 items imported.
5. Check the imported Taxonomy terms by visiting http://gho-2022-site.docksal/admin/structure/taxonomy/manage/needs_and_requirements/overview — you have to view a specific term to see the fields containing imported data.
6. Add a **Needs and Requirements** paragraph to the homepage to test. I added one in between the intro text and the card list. See example with redacted figures:

![Screenshot 2021-11-05 at 10-45-06 Global Humanitarian Overview 2021](https://user-images.githubusercontent.com/254753/140491926-36cc7408-a6d2-458a-8ff4-d2f24100592d.png)


