### PR TITLE
GHO-218: Download button paragraph type

### DIFF
--- a/config/core.entity_form_display.paragraph.download_button.default.yml
+++ b/config/core.entity_form_display.paragraph.download_button.default.yml
@@ -1,0 +1,25 @@
+uuid: 89b9143d-21d0-4c45-987a-df77417e9fb0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.download_button.field_link
+    - paragraphs.paragraphs_type.download_button
+  module:
+    - link
+id: paragraph.download_button.default
+targetEntityType: paragraph
+bundle: download_button
+mode: default
+content:
+  field_link:
+    weight: 0
+    settings:
+      placeholder_url: 'https://reliefweb.int/path/to/your-pdf'
+      placeholder_title: 'Download report'
+    third_party_settings: {  }
+    type: link_default
+    region: content
+hidden:
+  created: true
+  status: true

--- a/config/core.entity_view_display.paragraph.download_button.default.yml
+++ b/config/core.entity_view_display.paragraph.download_button.default.yml
@@ -1,0 +1,27 @@
+uuid: 760af3cf-e222-4830-ad33-3aa8490f9c1c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.download_button.field_link
+    - paragraphs.paragraphs_type.download_button
+  module:
+    - link
+id: paragraph.download_button.default
+targetEntityType: paragraph
+bundle: download_button
+mode: default
+content:
+  field_link:
+    weight: 0
+    label: hidden
+    settings:
+      trim_length: null
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    type: link
+    region: content
+hidden: {  }

--- a/config/field.field.paragraph.download_button.field_link.yml
+++ b/config/field.field.paragraph.download_button.field_link.yml
@@ -1,0 +1,23 @@
+uuid: d6b941e2-ab86-46c0-a989-af18b320152f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_link
+    - paragraphs.paragraphs_type.download_button
+  module:
+    - link
+id: paragraph.download_button.field_link
+field_name: field_link
+entity_type: paragraph
+bundle: download_button
+label: Link
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 1
+field_type: link

--- a/config/paragraphs.paragraphs_type.download_button.yml
+++ b/config/paragraphs.paragraphs_type.download_button.yml
@@ -1,0 +1,10 @@
+uuid: 9ced5edc-1dff-4231-88ae-9ad37dd8c32a
+langcode: en
+status: true
+dependencies: {  }
+id: download_button
+label: 'Download button'
+icon_uuid: null
+icon_default: null
+description: 'A button that points to a document somewhere on the internet.'
+behavior_plugins: {  }

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -19,6 +19,11 @@ gho-bottom-figure-row:
     theme:
       components/gho-bottom-figure-row/gho-bottom-figure-row.css: {}
 
+gho-download-button:
+  css:
+    theme:
+      components/gho-download-button/gho-download-button.css: {}
+
 gho-hero-image:
   css:
     theme:

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -78,6 +78,18 @@ function common_design_subtheme_preprocess_field(&$variables) {
       }
       break;
   }
+
+  // Add CD Button classes to field_link within download_button Paragraph type.
+  if ($variables['element']['#field_name'] == 'field_link' && $variables['element']['#object']->getType() === 'download_button') {
+    $variables['items'][0]['content']['#options']['attributes']['class'][] = 'cd-button cd-button--bold cd-button--uppercase';
+
+    // If no Link text was supplied, a URL will be in the title. In that case,
+    // we set a default value "Download report"
+    $has_url_in_title = strpos($variables['items'][0]['content']['#title'], 'http');
+    if ($has_url_in_title !== false && $has_url_in_title >= 0) {
+      $variables['items'][0]['content']['#title'] = t('Download report');
+    }
+  }
 }
 
 /**

--- a/html/themes/custom/common_design_subtheme/components/gho-download-button/README.md
+++ b/html/themes/custom/common_design_subtheme/components/gho-download-button/README.md
@@ -1,0 +1,4 @@
+Global Humanitarian Overview - Download button Component
+========================================================
+
+A download button that links to externally-hosted files.

--- a/html/themes/custom/common_design_subtheme/components/gho-download-button/gho-download-button.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-download-button/gho-download-button.css
@@ -1,0 +1,3 @@
+.gho-download-button {
+  margin: 1em 0;
+}

--- a/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-link--download-button.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/fields/field--paragraph--field-link--download-button.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a Download button's Link field.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ *
+ * @ingroup themeable
+ */
+#}
+{% for item in items %}
+  <div{{ item.attributes }}>{{ item.content }}</div>
+{% endfor %}

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--download-button.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--download-button.html.twig
@@ -1,0 +1,60 @@
+{#
+/**
+ * @file
+ * Theme implementation for a Download button paragraph.
+ *
+ * Overrides paragraphs/templates/paragraph.html.twig.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{{ attach_library('common_design_subtheme/gho-download-button') }}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'gho-download-button',
+    'content-width',
+  ]
+%}
+{% block paragraph %}
+  <div{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </div>
+{% endblock paragraph %}


### PR DESCRIPTION
# GHO-218

Adds a new Paragraph type that Editors use to link to PDF downloads from wherever they want in the content.

The UI is a Link field, nothing else. The template renders CD Button and for starters I left the colors at our default blue.

I think my preprocess logic is specific enough, but that's worth looking at since it's the only bit of custom code. It sets some classes, plus default text if none was provided: "Download report" (translatable).

### Link text omitted

<img width="953" alt="Screen Shot 2021-11-05 at 15 36 14" src="https://user-images.githubusercontent.com/254753/140528434-d804feea-1199-4b93-8467-695a7aadaca9.png">

### Link contains custom text: "Download chapter"

<img width="977" alt="Screen Shot 2021-11-05 at 15 35 46" src="https://user-images.githubusercontent.com/254753/140528494-f80ecf28-88be-4c37-b473-0cc79028b0de.png">
