### PR TITLE
GHO-219: Article Cards now link to their node

### DIFF
--- a/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
@@ -78,7 +78,7 @@
 }
 
 /**
- * We're using an invisble hyperlink that stretches over the top of each card
+ * We're using an invisible hyperlink that stretches over the top of each card
  * so that the entire surface is clickable/tappable.
  */
 .gho-article-card__link {

--- a/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-article-card/gho-article-card.css
@@ -4,6 +4,15 @@
   border: 1px solid var(--gho-article-card-border-color);
 }
 
+/**
+ * Have our card contents stretch to fill the flex item, and set its position
+ * for the read-more link defined below.
+ */
+.gho-article-card__content {
+  position: relative;
+  height: 100%;
+}
+
 /* Hide the "scroll down" SVG.
  *
  * Since Cards are used extensively on homepage, and our Hero Image template
@@ -66,4 +75,24 @@
 .gho-article-card .field--name-field-summary {
   margin: 1rem 0;
   padding: 0 1rem;
+}
+
+/**
+ * We're using an invisble hyperlink that stretches over the top of each card
+ * so that the entire surface is clickable/tappable.
+ */
+.gho-article-card__link {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  color: transparent;
+}
+.gho-article-card__link:hover {
+  color: transparent;
+}
+.gho-article-card__link:focus {
+  color: transparent;
+  outline: 3px solid black;
 }

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
@@ -90,10 +90,11 @@
   ]
 %}
 <article{{ attributes.addClass(classes) }}>
-  <div{{ content_attributes.addClass('node__content').addClass('gho-article__content') }}>
+  <div{{ content_attributes.addClass('node__content').addClass('gho-article-card__content') }}>
     {{ content.field_hero_image }}
     {{ content.field_section }}
     <h3 class="gho-article-card__title">{{ node.getTitle }}</h3>
     {{ content.field_summary }}
+    <a href="{{ url }}" class="gho-article-card__link" title="{{ 'Read this article'|t }}">{{ 'Read this article'|t }}</a>
   </div>
 </article>


### PR DESCRIPTION
# GHO-219

You can click on a card (or activate it with keyboard nav) and it will take you somewhere now! How advanced!

## Testing

@lazysoundsystem you should be able to load this branch and use the existing content to test this. No change is necessary within Drupal (besides maybe cache rebuild to grab the new CSS, depending on your local's twig settings)

I also added a focus style so that keyboard nav is usable:

<img width="1006" alt="Screen Shot 2021-11-08 at 14 12 36" src="https://user-images.githubusercontent.com/254753/140748221-1afaef59-db89-4940-bc0c-2d4fa35e5dc3.png">

