### PR TITLE
GHO-222: allow Editors to edit all users and manage roles on each user

### DIFF
--- a/config/social_auth.settings.yml
+++ b/config/social_auth.settings.yml
@@ -6,6 +6,7 @@ post_login: /
 redirect_user_form: false
 disable_admin_login: true
 disabled_roles:
+  editor: '0'
   administrator: '0'
 user_allowed: register
 _core:

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -19,6 +19,8 @@ permissions:
   - 'administer menu'
   - 'administer taxonomy'
   - 'administer url aliases'
+  - 'administer users'
+  - 'assign user roles'
   - 'bypass node access'
   - 'create achievement content'
   - 'create article content'


### PR DESCRIPTION
# GHO-222

Turned on some permissions for Editor role. They can now see the "People" admin menu item and click it to reveal all registered users. They can edit any user and assign roles and permissions.

Although the Permissions page says they'll be able to change username/email as well, those fields are locked and cannot be edited. I presume because of Social Auth module.

# Testing

- Log in with HID, NOT user/1
- Check for administrative menu item, click to reveal user list.
- Edit a user and add/remove a role from their account.