### PR TITLE
GHO-238: allow Article Cards to display alternate titles

### DIFF
--- a/config/core.entity_form_display.node.article.default.yml
+++ b/config/core.entity_form_display.node.article.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_caption
+    - field.field.node.article.field_card_title
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_pdf
@@ -29,14 +30,14 @@ bundle: article
 mode: default
 content:
   field_appeals:
-    weight: 2
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_author:
     type: inline_entity_form_complex
-    weight: 3
+    weight: 4
     settings:
       form_mode: default
       override_labels: true
@@ -52,7 +53,7 @@ content:
     third_party_settings: {  }
     region: content
   field_caption:
-    weight: 6
+    weight: 7
     settings:
       first:
         type: textfield
@@ -78,15 +79,23 @@ content:
     third_party_settings: {  }
     type: double_field
     region: content
+  field_card_title:
+    weight: 2
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   field_hero_image:
     type: media_library_widget
-    weight: 5
+    weight: 6
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   field_paragraphs:
-    weight: 9
+    weight: 10
     settings:
       preview_view_mode: preview
       nesting_depth: 4
@@ -95,7 +104,7 @@ content:
     type: layout_paragraphs
     region: content
   field_pdf:
-    weight: 4
+    weight: 5
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
@@ -108,7 +117,7 @@ content:
     type: options_select
     region: content
   field_summary:
-    weight: 8
+    weight: 9
     settings:
       rows: 5
       placeholder: ''
@@ -120,14 +129,14 @@ content:
     region: content
   field_thumbnail_image:
     type: media_library_widget
-    weight: 7
+    weight: 8
     settings:
       media_types: {  }
     third_party_settings: {  }
     region: content
   path:
     type: path
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -135,7 +144,7 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 11
+    weight: 12
     region: content
     third_party_settings: {  }
   title:

--- a/config/core.entity_form_display.node.article.home_page.yml
+++ b/config/core.entity_form_display.node.article.home_page.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_caption
+    - field.field.node.article.field_card_title
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_pdf
@@ -121,6 +122,7 @@ hidden:
   created: true
   field_appeals: true
   field_author: true
+  field_card_title: true
   field_pdf: true
   field_thumbnail_image: true
   langcode: true

--- a/config/core.entity_view_display.node.article.default.yml
+++ b/config/core.entity_view_display.node.article.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_caption
+    - field.field.node.article.field_card_title
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_pdf
@@ -47,6 +48,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: gho_caption
+    region: content
+  field_card_title:
+    weight: 7
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   field_hero_image:
     type: entity_reference_entity_view

--- a/config/core.entity_view_display.node.article.default.yml
+++ b/config/core.entity_view_display.node.article.default.yml
@@ -49,14 +49,6 @@ content:
     third_party_settings: {  }
     type: gho_caption
     region: content
-  field_card_title:
-    weight: 7
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
   field_hero_image:
     type: entity_reference_entity_view
     weight: 3
@@ -89,6 +81,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_card_title: true
   field_pdf: true
   field_report_link: true
   field_summary: true

--- a/config/core.entity_view_display.node.article.home_page.yml
+++ b/config/core.entity_view_display.node.article.home_page.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_caption
+    - field.field.node.article.field_card_title
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_pdf
@@ -83,6 +84,7 @@ content:
 hidden:
   field_appeals: true
   field_author: true
+  field_card_title: true
   field_pdf: true
   field_section: true
   field_thumbnail_image: true

--- a/config/core.entity_view_display.node.article.preview.yml
+++ b/config/core.entity_view_display.node.article.preview.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_caption
+    - field.field.node.article.field_card_title
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_pdf
@@ -66,6 +67,7 @@ content:
     region: content
 hidden:
   field_caption: true
+  field_card_title: true
   field_pdf: true
   field_report_link: true
   field_section: true

--- a/config/core.entity_view_display.node.article.related_article.yml
+++ b/config/core.entity_view_display.node.article.related_article.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_caption
+    - field.field.node.article.field_card_title
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_pdf
@@ -48,6 +49,7 @@ hidden:
   field_appeals: true
   field_author: true
   field_caption: true
+  field_card_title: true
   field_hero_image: true
   field_paragraphs: true
   field_pdf: true

--- a/config/core.entity_view_display.node.article.sub_article.yml
+++ b/config/core.entity_view_display.node.article.sub_article.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_caption
+    - field.field.node.article.field_card_title
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_pdf
@@ -73,6 +74,7 @@ content:
     type: layout_paragraphs
     region: content
 hidden:
+  field_card_title: true
   field_pdf: true
   field_report_link: true
   field_section: true

--- a/config/core.entity_view_display.node.article.teaser.yml
+++ b/config/core.entity_view_display.node.article.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_caption
+    - field.field.node.article.field_card_title
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_pdf
@@ -43,6 +44,7 @@ hidden:
   field_appeals: true
   field_author: true
   field_caption: true
+  field_card_title: true
   field_hero_image: true
   field_paragraphs: true
   field_pdf: true

--- a/config/core.entity_view_display.node.article.teaser_card.yml
+++ b/config/core.entity_view_display.node.article.teaser_card.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.article.field_appeals
     - field.field.node.article.field_author
     - field.field.node.article.field_caption
+    - field.field.node.article.field_card_title
     - field.field.node.article.field_hero_image
     - field.field.node.article.field_paragraphs
     - field.field.node.article.field_pdf
@@ -30,6 +31,14 @@ targetEntityType: node
 bundle: article
 mode: teaser_card
 content:
+  field_card_title:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
   field_hero_image:
     type: media_thumbnail
     weight: 0
@@ -49,7 +58,7 @@ content:
     region: content
   field_summary:
     type: text_default
-    weight: 2
+    weight: 3
     region: content
     label: hidden
     settings: {  }

--- a/config/field.field.node.article.field_card_title.yml
+++ b/config/field.field.node.article.field_card_title.yml
@@ -1,0 +1,19 @@
+uuid: b10fc906-4043-4d3c-b534-c79db1c82e80
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_card_title
+    - node.type.article
+id: node.article.field_card_title
+field_name: field_card_title
+entity_type: node
+bundle: article
+label: 'Card Title'
+description: 'Optional: an alternate title to display when the Article appears as a Card. It doesn''t display anywhere else.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/field.storage.node.field_card_title.yml
+++ b/config/field.storage.node.field_card_title.yml
@@ -1,0 +1,21 @@
+uuid: 5a8bc16f-a8f5-4d21-8e34-8f98e254920b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_card_title
+field_name: field_card_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/nodes/node--article--teaser-card.html.twig
@@ -89,13 +89,14 @@
     'clearfix',
   ]
 %}
+{% set card_title = content.field_card_title|render ? content.field_card_title : node.getTitle %}
 {% set text = content.field_summary|render|striptags|trim %}
 {% set summary_trimmed = text|length > 180 ? text|slice(0, 181)|split(' ')|slice(0, -1)|join(' ') ~ '…' : text %}
 <article{{ attributes.addClass(classes) }}>
   <div{{ content_attributes.addClass('node__content').addClass('gho-article-card__content') }}>
     {{ content.field_hero_image }}
     {{ content.field_section }}
-    <h3 class="gho-article-card__title">{{ node.getTitle }}</h3>
+    <h3 class="gho-article-card__title">{{ card_title }}</h3>
     <p class="gho-article-card__summary">{{ summary_trimmed }}</p>
     <a href="{{ url }}" class="gho-article-card__link" title="{{ 'Read this article'|t }}">{{ 'Read this article'|t }}</a>
   </div>


### PR DESCRIPTION
# GHO-238

Article Cards now display the short title if filled in, the default title if left blank.

## Testing

1. Enter some Card titles and see how it affects the lists on the Homepage
2. Translate an Article and confirm it shows up translated when appropriate.