### PR TITLE
GHO-210: full-bleed interactive content para types

### DIFF
--- a/config/core.entity_form_display.paragraph.interactive_content.default.yml
+++ b/config/core.entity_form_display.paragraph.interactive_content.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.interactive_content.field_dataset
     - field.field.paragraph.interactive_content.field_embed_code
+    - field.field.paragraph.interactive_content.field_full_width
     - field.field.paragraph.interactive_content.field_image
     - field.field.paragraph.interactive_content.field_link
     - field.field.paragraph.interactive_content.field_show_datawrapper
@@ -21,7 +22,7 @@ bundle: interactive_content
 mode: default
 content:
   field_dataset:
-    weight: 6
+    weight: 7
     settings:
       placeholder_url: 'Ex: https://humdata.org/dataset'
       placeholder_title: 'Ex: Office for Coordination of Humanitarian Affairs'
@@ -29,22 +30,29 @@ content:
     type: gho_dataset_link
     region: content
   field_embed_code:
-    weight: 4
+    weight: 5
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
     type: gho_datawrapper
     region: content
+  field_full_width:
+    weight: 1
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_image:
-    weight: 3
+    weight: 4
     settings:
       media_types: {  }
     third_party_settings: {  }
     type: media_library_widget
     region: content
   field_link:
-    weight: 2
+    weight: 3
     settings:
       placeholder_url: 'Ex: https://datawrapper.de/content-page'
       placeholder_title: ''
@@ -52,14 +60,14 @@ content:
     type: link_default
     region: content
   field_show_datawrapper:
-    weight: 5
+    weight: 6
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
   field_title:
-    weight: 1
+    weight: 2
     settings:
       size: 60
       placeholder: ''
@@ -74,7 +82,7 @@ content:
     region: content
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 8
     region: content
     settings:
       display_label: true

--- a/config/core.entity_view_display.paragraph.interactive_content.default.yml
+++ b/config/core.entity_view_display.paragraph.interactive_content.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.interactive_content.field_dataset
     - field.field.paragraph.interactive_content.field_embed_code
+    - field.field.paragraph.interactive_content.field_full_width
     - field.field.paragraph.interactive_content.field_image
     - field.field.paragraph.interactive_content.field_link
     - field.field.paragraph.interactive_content.field_show_datawrapper
@@ -33,6 +34,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: gho_datawrapper
+    region: content
+  field_full_width:
+    weight: 6
+    label: hidden
+    settings:
+      format: custom
+      format_custom_true: 'true'
+      format_custom_false: 'false'
+    third_party_settings: {  }
+    type: boolean
     region: content
   field_image:
     weight: 2

--- a/config/core.entity_view_display.paragraph.interactive_content.preview.yml
+++ b/config/core.entity_view_display.paragraph.interactive_content.preview.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.paragraph.preview
     - field.field.paragraph.interactive_content.field_dataset
     - field.field.paragraph.interactive_content.field_embed_code
+    - field.field.paragraph.interactive_content.field_full_width
     - field.field.paragraph.interactive_content.field_image
     - field.field.paragraph.interactive_content.field_link
     - field.field.paragraph.interactive_content.field_show_datawrapper
@@ -70,5 +71,6 @@ content:
     type: entity_reference_label
     region: content
 hidden:
+  field_full_width: true
   field_link: true
   field_show_datawrapper: true

--- a/config/field.field.paragraph.interactive_content.field_full_width.yml
+++ b/config/field.field.paragraph.interactive_content.field_full_width.yml
@@ -1,0 +1,23 @@
+uuid: 8e84007c-901f-4a80-ac21-644328dfd021
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_full_width
+    - paragraphs.paragraphs_type.interactive_content
+id: paragraph.interactive_content.field_full_width
+field_name: field_full_width
+entity_type: paragraph
+bundle: interactive_content
+label: 'Display at full width?'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes, full width'
+  off_label: 'No, align with content'
+field_type: boolean

--- a/config/field.storage.paragraph.field_full_width.yml
+++ b/config/field.storage.paragraph.field_full_width.yml
@@ -1,0 +1,18 @@
+uuid: e122c6dc-3e9e-4479-87b1-cab0bd683e23
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_full_width
+field_name: field_full_width
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.libraries.yml
@@ -145,6 +145,8 @@ gho-interactive-content:
   css:
     theme:
       components/gho-interactive-content/gho-interactive-content.css: {}
+  js:
+    components/gho-interactive-content/gho-interactive-content.js: {}
 
 gho-page-404:
   css:

--- a/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.css
+++ b/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.css
@@ -1,6 +1,17 @@
 .gho-interactive-content {
   margin: 3rem 0 0 0;
 }
+
+.gho-interactive-content--full-width {
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: calc(-50vw + (var(--scrollbar-width, 15px) / 2));
+  margin-right: calc(-50vw + (var(--scrollbar-width, 15px) / 2));
+  max-width: calc(100vw - var(--scrollbar-width, 15px));
+  width: calc(100vw - var(--scrollbar-width, 15px));
+}
+
 .gho-interactive-content .field--name-field-image {
   margin-bottom: 1.5rem;
 }

--- a/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.js
+++ b/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.js
@@ -4,10 +4,10 @@
   Drupal.behaviors.ghoInteractiveContent = {
     attach: function (context, settings) {
       // Measure width of vertical scrollbar.
-      this.getScrollBarWidth();
+      this.setScrollBarWidth();
 
       // Listen for window.resize and recalculate scrollbar width.
-      window.addEventListener('resize', this.getScrollBarWidth);
+      window.addEventListener('resize', this.setScrollBarWidth);
     },
 
     /**
@@ -15,7 +15,7 @@
      *
      * @return {int} width in pixels
      */
-    getScrollBarWidth: function() {
+    setScrollBarWidth: function() {
       // So we can store our final result.
       var scrollBarWidth;
 

--- a/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.js
+++ b/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.js
@@ -12,8 +12,6 @@
 
     /**
      * @see https://stackoverflow.com/a/986977
-     *
-     * @return {int} width in pixels
      */
     setScrollBarWidth: function () {
       // So we can store our final result.

--- a/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.js
+++ b/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.js
@@ -1,0 +1,56 @@
+(function () {
+  'use strict';
+
+  Drupal.behaviors.ghoInteractiveContent = {
+    attach: function (context, settings) {
+      // Measure width of vertical scrollbar.
+      this.getScrollBarWidth();
+
+      // Listen for window.resize and recalculate scrollbar width.
+      window.addEventListener('resize', this.getScrollBarWidth);
+    },
+
+    /**
+     * @see https://stackoverflow.com/a/986977
+     *
+     * @return {int} width in pixels
+     */
+    getScrollBarWidth: function() {
+      // So we can store our final result.
+      var scrollBarWidth;
+
+      // Set up a <p> and <div> to create scrollable content.
+      var inner = document.createElement('p');
+      inner.style.width = '100%';
+      inner.style.height = '200px';
+
+      var outer = document.createElement('div');
+      outer.style.position = 'absolute';
+      outer.style.top = '0px';
+      outer.style.left = '0px';
+      outer.style.visibility = 'hidden';
+      outer.style.width = '200px';
+      outer.style.height = '150px';
+      outer.style.overflow = 'hidden';
+      outer.appendChild(inner);
+
+      // Insert into DOM and calculate scrollbar.
+      document.body.appendChild(outer);
+      var w1 = inner.offsetWidth;
+      outer.style.overflow = 'scroll';
+      var w2 = inner.offsetWidth;
+      if (w1 === w2) {
+        w2 = outer.clientWidth;
+      }
+
+      // Store final result.
+      scrollBarWidth = w1 - w2;
+
+      // Clean up DOM.
+      document.body.removeChild(outer);
+
+      // Set on :root so that all components have access to this number.
+      document.documentElement.style.setProperty('--scrollbar-width', scrollBarWidth + 'px');
+    },
+  };
+}());

--- a/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.js
+++ b/html/themes/custom/common_design_subtheme/components/gho-interactive-content/gho-interactive-content.js
@@ -15,7 +15,7 @@
      *
      * @return {int} width in pixels
      */
-    setScrollBarWidth: function() {
+    setScrollBarWidth: function () {
       // So we can store our final result.
       var scrollBarWidth;
 
@@ -51,6 +51,6 @@
 
       // Set on :root so that all components have access to this number.
       document.documentElement.style.setProperty('--scrollbar-width', scrollBarWidth + 'px');
-    },
+    }
   };
-}());
+})();

--- a/html/themes/custom/common_design_subtheme/js/login_destination.js
+++ b/html/themes/custom/common_design_subtheme/js/login_destination.js
@@ -2,11 +2,12 @@
  * @file
  * Attach destination to login link.
  */
-
 (function () {
+  'use strict';
+
   var loginLink = document.querySelector('a[href="/user/login/hid"]');
   if (loginLink) {
     loginLink.href += '?destination=' + location.pathname + location.search + location.hash;
   }
-}());
+})();
 

--- a/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--interactive-content.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/paragraphs/paragraph--interactive-content.html.twig
@@ -48,9 +48,9 @@
     'paragraph--type--' ~ paragraph.bundle|clean_class,
     view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
     not paragraph.isPublished() ? 'paragraph--unpublished',
-    'gho-interactive-content',
     'gho-aside',
-    'content-width',
+    'gho-interactive-content',
+    content.field_full_width|render|striptags|trim == 'true' ? 'gho-interactive-content--full-width' : 'content-width',
   ]
 %}
 {% block paragraph %}
@@ -65,7 +65,7 @@
       {% else %}
         {{ content.field_image }}
       {% endif %}
-      {{ content|without(['field_type', 'field_title', 'field_embed_code', 'field_image', 'field_show_datawrapper']) }}
+      {{ content|without(['field_type', 'field_title', 'field_embed_code', 'field_image', 'field_show_datawrapper', 'field_full_width']) }}
     {% endblock %}
   </div>
 {% endblock paragraph %}


### PR DESCRIPTION
# GHO-210

Covers screen edge-to-edge without ever causing horizontal scroll. Since this is still an "unsolved" problem using declarative CSS only, I made an even listener which checks for scrollbars on page load and during each resize.

## Testing

- checkout, `drush cim`, `drush cr`
- Find an Interactive Content paragraph type and edit it to enable the "Display at full-width" checkbox
- Load the page and confirm it both works, and there's no horizontal scrollbar