### PR TITLE
[HOTFIX] Avoid an error 500 on untranslated content.

### DIFF
--- a/html/modules/custom/gho_general/gho_general.module
+++ b/html/modules/custom/gho_general/gho_general.module
@@ -220,6 +220,10 @@ function gho_general_preprocess_menu(&$variables) {
 function gho_general_menu_item_cleanup(array &$items, $language) {
   // Check language for current menu depth.
   foreach ($items as $key => &$item) {
+    // Do not try to process this item if there is no original link.
+    if (empty($item['original_link'])) {
+      continue;
+    }
     $menuLinkEntity = gho_general_load_link_entity_by_link($item['original_link']);
 
     // Ignore if we don´t have a menu object.


### PR DESCRIPTION
This was throwing 500 errors on production upon launch (and this bad hotfix makes it shows a styled 404, which is less bad).

As authenticated user, the untranslated content is displayed, which I'm going to guess is what we actually also want for anonymous users. I will leave that as an exercise for the reader, though.